### PR TITLE
Fix build on SmartOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REBAR=$(shell which rebar || echo ./rebar)
+REBAR = $(shell test -e `which rebar` 2>/dev/null && which rebar || echo "./rebar")
 DEPSOLVER_PLT=$(CURDIR)/.depsolver_plt
 
 all: compile

--- a/c_src/inert_drv.c
+++ b/c_src/inert_drv.c
@@ -26,6 +26,16 @@
 #include "erl_driver.h"
 #include "ei.h"
 
+/* Solaris needs u_int32_t defined */
+#ifdef __sun__
+  #ifndef _uint_defined
+    #include <stdint.h>
+    typedef uint32_t u_int32_t;
+    #define _uint_defined
+  #endif /* _uint_defined */
+#endif /* SOLARIS */
+
+
 #define get_int32(s) ((((unsigned char*) (s))[0] << 24) | \
                       (((unsigned char*) (s))[1] << 16) | \
                       (((unsigned char*) (s))[2] << 8)  | \


### PR DESCRIPTION
The first commit adds proper `rebar` handling in the case of no rebar in path on Solaris.  This was also done to https://github.com/msantos/procket/pull/19

The second commit simply adds support to an unknown type on Solaris.  The other solution would be to require C99 and use stdint.h and uint32_t, but we didn't know if requiring C99 was possible.  This pull request requires C99 on Solaris only.  I tested on OSX, Debian, and SmartOS, I have not tested on super-old Solaris.  I don't know how crazy you want me to get with the fix.
