### PR TITLE
OTP21 and rebar3 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,14 @@
     {"(freebsd|openbsd|netbsd)", compile, "gmake -C c_src"}
     ]}.
 
+{profiles, [
+    {test, [
+        {deps, [
+            {procket, {git, "https://github.com/msantos/procket.git", {branch, "master"}}}
+        ]}
+    ]}
+]}.
+
 {post_hooks, [
     {"(linux|darwin|solaris)", clean, "make -C c_src clean"},
     {"(freebsd|openbsd|netbsd)", clean, "gmake -C c_src clean"}

--- a/test/inert_SUITE.erl
+++ b/test/inert_SUITE.erl
@@ -152,7 +152,7 @@ read(Pid, FD, Bytes, N) ->
 
 connect(Port, Runs, Bytes) ->
     {ok, Socket} = gen_tcp:connect("localhost", Port, []),
-    Bin = crypto:rand_bytes(Bytes),
+    Bin = crypto:strong_rand_bytes(Bytes),
     ok = gen_tcp:send(Socket, Bin),
     ok = gen_tcp:close(Socket),
     connect(Port, Runs-1, Bytes).


### PR DESCRIPTION
This simply adds procket as a test-only dep for rebar3 and updates a deprecated/removed function.