### PR TITLE
Use C99 types

### DIFF
--- a/c_src/inert_drv.c
+++ b/c_src/inert_drv.c
@@ -26,16 +26,6 @@
 #include "erl_driver.h"
 #include "ei.h"
 
-/* Solaris needs u_int32_t defined */
-#ifdef __sun__
-  #ifndef _uint_defined
-    #include <stdint.h>
-    typedef uint32_t u_int32_t;
-    #define _uint_defined
-  #endif /* _uint_defined */
-#endif /* SOLARIS */
-
-
 #define get_int32(s) ((((unsigned char*) (s))[0] << 24) | \
                       (((unsigned char*) (s))[1] << 16) | \
                       (((unsigned char*) (s))[2] << 8)  | \
@@ -55,7 +45,7 @@ typedef struct {
 
 typedef struct {
     ErlDrvPort port;
-    u_int32_t maxfd;
+    uint32_t maxfd;
     inert_state_t *state;
 } inert_drv_t;
 


### PR DESCRIPTION
`u_int32_t` is not a standard type in c, but it is defined on several platforms in `sys/types.h`. However, inert doesn't include that header. Instead, inert has relied on transitively-including it via `erl_driver.h` and `ei.h`. Something changed in OTP23, breaking that transitive include on some Linux distros. We might as well use `uint32_t` since inert already has a hard [dependency](https://github.com/msantos/inert/blob/master/c_src/Makefile#L29) on C99.

I ran include-what-you-use to make sure all the `#includes` are up to date:

```
$ bear rebar3 compile # generate compile_commands.json via build-ear
$ iwyu_tool.py -p compile_commands.json

inert_drv.c should add these lines:
#include <stdint.h>                 // for int32_t
#include <sys/_types/_u_int32_t.h>  // for u_int32_t
#include <sys/errno.h>              // for EBADF, EBUSY, EINVAL
#include <sys/fcntl.h>              // for fcntl, F_GETFD
#include "erl_drv_nif.h"            // for ErlDrvMonitor

inert_drv.c should remove these lines:
- #include <errno.h>  // lines 16-16
- #include <fcntl.h>  // lines 24-24
- #include <sys/time.h>  // lines 18-18
- #include <unistd.h>  // lines 23-23
- #include "ei.h"  // lines 27-27

The full include-list for inert_drv.c:
#include <stdint.h>                 // for int32_t
#include <stdio.h>                  // for NULL, size_t
#include <string.h>                 // for memset, strlen, memcpy
#include <sys/_types/_u_int32_t.h>  // for u_int32_t
#include <sys/errno.h>              // for EBADF, EBUSY, EINVAL
#include <sys/fcntl.h>              // for fcntl, F_GETFD
#include <sys/resource.h>           // for rlimit, getrlimit, RLIMIT_NOFILE
#include "erl_driver.h"             // for driver_select, ErlDrvData, driver...
#include "erl_drv_nif.h"            // for ErlDrvMonitor
---
```