### PR TITLE
Fix OTP23/Alpine builds

### DIFF
--- a/c_src/inert_drv.c
+++ b/c_src/inert_drv.c
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 
 #include <string.h>
+#include <stdint.h>
 
 #include <unistd.h>
 #include <fcntl.h>


### PR DESCRIPTION
For some reason, our builds are failing with the combo of Alpine Linux docker and OTP23 without including `stdint.h`.

CC @dpezely
